### PR TITLE
fixing what seems to be a bug in HBaseRecordReaderGranular

### DIFF
--- a/src/main/java/parallelai/spyglass/hbase/HBaseRecordReaderGranular.java
+++ b/src/main/java/parallelai/spyglass/hbase/HBaseRecordReaderGranular.java
@@ -26,7 +26,7 @@ public class HBaseRecordReaderGranular extends HBaseRecordReaderBase {
 
   private byte[] lastSuccessfulRow;
   private ResultScanner scanner;
-  private long timestamp;
+  private long timestamp = -1;
   private int rowcount = 0;
 
     @Override


### PR DESCRIPTION
since timestamp is not initialized and therefore defaults to 0, the scan timestamp will also get set to 0 by default which doesn't make sense. see below code snippet.

```
if(timestamp != -1) {
    scan.setTimeStamp(timestamp);
}
```
