### PR TITLE
#20 Upgraded CDH from 5.1.0 to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <name>Cascading and Scalding wrapper for HBase with advanced features</name>
     <groupId>parallelai</groupId>
     <artifactId>parallelai.spyglass</artifactId>
-    <version>2.10_0.10_CDH5.2.1</version>
+    <version>2.10_0.10_CDH5.2.1_4.4</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
Upgraded CDH from 5.1.0 to 5.2.1, HBase from 0.98.1 to 0.98.6 and updated maven compiler (target) version to 1.7. Removed dependencies hbase-common, hbase-client and hbase-protocol as they are transitive dependencies of hbase-server already (also to keep the version consistent with server). Removed dependency hadoop-core and hadoop-common and added hadoop-client instead. Added dependency for jsch.  Removed comments and commented out lines.
